### PR TITLE
Add Python cache files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@
 *.pem
 *.byok
 
-
-
+# Python cache
+__pycache__/
+*.pyc
+*.pyo


### PR DESCRIPTION
Added __pycache__/, *.pyc, and *.pyo to .gitignore to prevent Python bytecode files from being tracked in the repository.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Python cache/bytecode patterns to `.gitignore` to avoid tracking generated files.
> 
> - Update `.gitignore` to ignore `__pycache__/`, `*.pyc`, and `*.pyo`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 912607725260e8f1245020a36bf495007eee37fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->